### PR TITLE
Feature: Implement and Test Load Retrieval from Network to DataModel

### DIFF
--- a/Code/ComponentFactory.py
+++ b/Code/ComponentFactory.py
@@ -1,7 +1,7 @@
 
 from Framework import GlobalRegistry as gbl
 #from ComponentManager import Busbar, Generator, Load, Branch
-from ComponentManager import Busbar, Generator
+from ComponentManager import Busbar, Generator, Load
 
 class ComponentFactory():
     def __init__(self):
@@ -15,9 +15,9 @@ class ComponentFactory():
         """Creates a generator component with the given BusID and GenID"""
         return Generator(BusID, GenID)
     
-    # def createload(self, BusID, LoadID):
-    #     """Creates a load component with the given BusID and LoadID"""
-    #     return Load(BusID, LoadID)
+    def createload(self, BusID, LoadID):
+        """Creates a load component with the given BusID and LoadID"""
+        return Load(BusID, LoadID)
     
     # def createbranch(self, BusID1, BusID2, BranchID):
     #     """Creates a branch component with the given BusID1, BusID2 and BranchID"""

--- a/Code/ComponentManager.py
+++ b/Code/ComponentManager.py
@@ -206,3 +206,61 @@ class Generator(ComponentBaseTemplate):
         if self.BasicEngineModelUpdater:
             bOK = self.BasicEngineModelUpdater.getgeneratorstatusfromengine(self)
         return bOK
+    
+class Load(ComponentBaseTemplate):
+    def __init__(self, BusID, LoadID):
+        ComponentBaseTemplate.__init__(self)
+        try:
+            BusID = int(BusID)
+        except:
+            BusID = str(BusID)
+
+        # load unique identifier/ network mapping properties
+        self.BusID = BusID
+        self.LoadID = str(LoadID)
+        self.BusIndex = 0
+        self.BusName = ''
+        self.oBus = None
+        
+        # load operational attributes
+        self.MW = 0.0
+        self.MVar = 0.0
+        self.MWCapacity = 0.0
+        self.MSG = 0.0
+        self.Qmax = 99999
+        self.Qmin = -99999
+        
+        # Engine model updater based on the type of analysis
+        self.BasicEngineModelUpdater = None
+        self.LoadFlowEngineModelUpdater = None
+        self.HarmonicEngineModelUpdater = None
+        self.ContingencyAnalysisEngineModelUpdater = None
+        
+        
+    def getdatamodelcomponentreadablename(self) -> str:
+        return f"{self.BusName}-{self.LoadID})"
+    
+    def getdatamodelcomponentfromengine(self):
+        bOK = False
+        if self.BasicEngineModelUpdater:
+            bOK = self.BasicEngineModelUpdater.getloadfromengine(self)
+        return bOK
+    
+    def setdatamodelcomponenttoengine(self):
+        bOK = False
+        if self.BasicEngineModelUpdater:
+            bOK = self.BasicEngineModelUpdater.setloadtoengine(self)
+        return bOK
+    
+    def setdatamodelcomponentstatustoengine(self):
+        # Logic to update the engine with the load status
+        bOK = False
+        if self.BasicEngineModelUpdater:
+            bOK = self.BasicEngineModelUpdater.updateloadstatus(self)
+        return bOK
+    def getdatamodelcomponentstatusfromengine(self):
+        bOK = False
+        if self.BasicEngineModelUpdater:
+            bOK = self.BasicEngineModelUpdater.getloadstatusfromengine(self)
+        return bOK
+    

--- a/Code/DataModelManager.py
+++ b/Code/DataModelManager.py
@@ -195,19 +195,25 @@ class DataModelManager:
 
     def addloadtotab(self, oLoad):
         """Add a load to the Load_TAB list and update busbar mapping."""
+        bOK = True
+        if oLoad is None:
+            bOK = False
+            return bOK
         load_index = len(self.Load_TAB)
         self.Load_TAB.append(oLoad)
 
         # If using busbar map, add load index to the busbar's load list
         if self.b_UsebusbarMap:
-            busID = oLoad.getattribute("BusID")
+            busID = oLoad.__getattribute__("BusID")
             if busID is not None:
                 oBus, _ = self.findbusbar(busID)
                 if oBus is not None:
                     # Ensure the busbar has a Loads list
                     if not hasattr(oBus, 'Loads'):
                         oBus.Loads = []
-                    oBus.Loads.append(load_index)
+                    bOK = oBus.Loads.append(load_index)
+                    bOK = True
+        return bOK
 
     def findload(self, BusID, LoadID):
         """

--- a/Code/main.py
+++ b/Code/main.py
@@ -8,4 +8,5 @@ if __name__ == "__main__":
     gbl.Engine.activatepowerfactorynetwork(r"Personal_Learning\Load Flow")
     gbl.Engine.activatepowerfactorystudycase("Study Case")
     gbl.DataModelInterface.getbusbarsfromnetwork()
+    gbl.DataModelInterface.getloadsfromnetwork()
     print("Framework initialized and ready to use!")


### PR DESCRIPTION
## Description
This pull request addresses sub-issue #28 by implementing and testing the retrieval of load objects from the PowerFactory network and integrating them into the data model.

## Key Changes
- ✅ Added and refined the `getloadsfromnetwork` method in `EnginePowerFactoryDataModelInterface` to extract load elements from the network  
- ✅ Standardized bus ID formatting and ensured loads are associated with their parent busbars using helper methods  
- ✅ Enhanced error handling and logging for missing or incomplete load data  
- ✅ Updated `FrameworkInitialiser` to centralize initialization and connect all major modules (messaging, engine, data model interface, data factory, data model manager)  
- ✅ Ensured only in-service loads are retrieved and added to `DataModelManager.Load_TAB`  
- ✅ Improved framework status reporting and resource cleanup logic  

These changes ensure that **load data is reliably and accurately transferred** from the PowerFactory network to the data model, with **clear association to parent busbars** and **robust error handling**.

## Acceptance Criteria
- [ ] All in-service loads are retrieved and added to `DataModelManager.Load_TAB`  
- [ ] Each load is correctly associated with its parent busbar  
- [ ] The process is logged and tested  